### PR TITLE
Frontend: Fix React Native Elements Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist/
 web-build/
 expo-env.d.ts
 
+# Caches
+.vscode
+
 # Native
 *.orig.*
 *.jks

--- a/frontend/app/components/search/Search.tsx
+++ b/frontend/app/components/search/Search.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { StyleProp, TouchableHighlight, View, ViewStyle } from "react-native";
-import { Icon, SearchBar } from "react-native-elements";
+import { Icon, SearchBar } from "@rneui/themed";
 import styles from "./styles";
 import SearchResultInterface from "@/app/types/SearchResultInterface";
 import searchApi from "@/app/services/SearchApi";
@@ -52,7 +52,6 @@ export default function Search({ style }: { style: StyleProp<ViewStyle> }) {
                 size: Sizing.icons.x25,
               }}
               rightIconContainerStyle={styles.rightIconContainer}
-              searchIcon={() => {}}
               lightTheme={true}
             />
 

--- a/frontend/app/components/search/SearchResultDisplay.tsx
+++ b/frontend/app/components/search/SearchResultDisplay.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-native";
 import styles from "./styles";
 import SearchResultInterface from "@/app/types/SearchResultInterface";
-import { Icon } from "react-native-elements";
+import { Icon } from "@rneui/themed";
 import { Colors } from "@/app/styles";
 
 export default function SearchResultDisplay({

--- a/frontend/app/components/search/SearchResults.tsx
+++ b/frontend/app/components/search/SearchResults.tsx
@@ -1,7 +1,7 @@
 import { FlatList, Text, TouchableHighlight, View } from "react-native";
 import styles, { ROW_HEIGHT } from "./styles";
 import SearchResultInterface from "@/app/types/SearchResultInterface";
-import { Icon } from "react-native-elements";
+import { Icon } from "@rneui/themed";
 import { noBusesFound } from "@/app/utils/strings";
 import { Colors } from "@/app/styles";
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,6 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-native": "0.76.3",
-        "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-maps": "^1.20.1",
         "react-native-reanimated": "~3.16.1",
@@ -10443,12 +10442,6 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -11581,15 +11574,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/opencollective-postinstall": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "license": "MIT",
-      "bin": {
-        "opencollective-postinstall": "index.js"
-      }
-    },
     "node_modules/ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -12490,52 +12474,6 @@
         }
       }
     },
-    "node_modules/react-native-elements": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-3.4.3.tgz",
-      "integrity": "sha512-VtZc25EecPZyUBER85zFK9ZbY6kkUdcm1ZwJ9hdoGSCr1R/GFgxor4jngOcSYeMvQ+qimd5No44OVJW3rSJECA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react-native-vector-icons": "^6.4.6",
-        "color": "^3.1.2",
-        "deepmerge": "^4.2.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "lodash.isequal": "^4.5.0",
-        "opencollective-postinstall": "^2.0.3",
-        "react-native-ratings": "8.0.4",
-        "react-native-size-matters": "^0.3.1"
-      },
-      "peerDependencies": {
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-vector-icons": ">7.0.0"
-      }
-    },
-    "node_modules/react-native-elements/node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
-    "node_modules/react-native-elements/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/react-native-elements/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz",
@@ -12588,19 +12526,6 @@
         }
       }
     },
-    "node_modules/react-native-ratings": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.0.4.tgz",
-      "integrity": "sha512-Xczu5lskIIRD6BEdz9A0jDRpEck/SFxRqiglkXi0u67yAtI1/pcJC76P4MukCbT8K4BPVl+42w83YqXBoBRl7A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-reanimated": {
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.3.tgz",
@@ -12646,15 +12571,6 @@
       },
       "peerDependencies": {
         "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-size-matters": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
-      "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==",
-      "license": "MIT",
-      "peerDependencies": {
         "react-native": "*"
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "@expo/vector-icons": "^14.0.2",
         "@react-navigation/bottom-tabs": "^7.0.0",
         "@react-navigation/native": "^7.0.0",
+        "@rneui/base": "^4.0.0-rc.7",
+        "@rneui/themed": "^4.0.0-rc.8",
         "expo": "~52.0.17",
         "expo-blur": "~14.0.1",
         "expo-constants": "~17.0.3",
@@ -4120,6 +4122,88 @@
       "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "node_modules/@rneui/base": {
+      "version": "4.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rneui/base/-/base-4.0.0-rc.7.tgz",
+      "integrity": "sha512-dffzoYek3Qp+7wJzC42QjI/Fu1HOUNxFIR88t1laDrBV5QZQB55f+Vu5zLbC80/bh1b8fYtl63HTIWpORuA3Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-native-vector-icons": "^6.4.10",
+        "color": "^3.2.1",
+        "deepmerge": "^4.2.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-native-ratings": "^8.1.0",
+        "react-native-size-matters": "^0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "react-native-safe-area-context": "^3.1.9 || ^4.0.0",
+        "react-native-vector-icons": ">7.0.0"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/@rneui/base/node_modules/react-native-ratings": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz",
+      "integrity": "sha512-+QOJ4G3NjVkI1D+tk4EGx1dCvVfbD2nQdkrj9cXrcAoEiwmbep4z4bZbCKmWMpQ5h2dqbxABU8/eBnbDmvAc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/react-native-size-matters": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.4.2.tgz",
+      "integrity": "sha512-DKE3f/sdcozd24oASgkP1iGg+YU3HoajRa5k3a4wkRzpiqREq8SGX12Y5zBgAt/8IivLQoTMYkyQu1/Giuy+zQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/@rneui/themed": {
+      "version": "4.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@rneui/themed/-/themed-4.0.0-rc.8.tgz",
+      "integrity": "sha512-8L/XOrL9OK/r+/iBLvx63TbIdZOXF8SIjN9eArMYm6kRbMr8m4BitXllDN8nBhBsSPNYvL6EAgjk+i2MfY4sBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "@rneui/base": "4.0.0-rc.7"
       }
     },
     "node_modules/@segment/loosely-validate-event": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "jest-expo": "~52.0.2",
         "metro": "^0.81.0",
         "react-test-renderer": "18.3.1",
-        "typescript": "^5.3.3"
+        "typescript": "5.7.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/native": "^7.0.0",
+    "@rneui/base": "^4.0.0-rc.7",
+    "@rneui/themed": "^4.0.0-rc.8",
     "expo": "~52.0.17",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "jest-expo": "~52.0.2",
     "metro": "^0.81.0",
     "react-test-renderer": "18.3.1",
-    "typescript": "^5.3.3"
+    "typescript": "5.7.2"
   },
   "private": true
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-maps": "^1.20.1",
     "react-native-reanimated": "~3.16.1",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,8 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "jsx": "react-jsx"  // or "react-jsxdev"
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
This PR fixes the installed React Native Elements version. We are using v4 but previously we installed v3.

This also includes other compilation errors, including missing React auto-imports and gitignores.